### PR TITLE
Tt 6387 work when sprockets is not used

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 coverage
 Gemfile.lock
+pkg/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased **
+
+* [TT-6387] Fix initalisation error when sprockets is not installed
+
 ## Production Toolkit 0.3.0 ##
 
 * [TT-6291] Filter additional headers / params from rollbar

--- a/lib/production_toolkit/initializers/lograge.rb
+++ b/lib/production_toolkit/initializers/lograge.rb
@@ -3,7 +3,7 @@ if defined?(Rails) && Rails.env.production?
     config.lograge.enabled = true
 
     # Disable sprockets asset logging
-    config.assets.logger = false
+    config.assets.logger = false if config.respond_to?(:assets)
 
     # Optionally add params hash, and timestamp
     config.lograge.custom_options = lambda do |event|


### PR DESCRIPTION
### WHY

Most of our rails apps are api only which means sprockets is not installed and config.assets will break the startup.