### PR TITLE
Tt 6412 ignore health check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Production Toolkit Unreleased ##
+
+* [TT-6412] Ignore logging health checks
+* [TT-6412] Add additional headers to be scrubed from rollbar
+
 ## Production Toolkit 0.3.1 ##
 
 * [TT-6387] Fix initalisation error when sprockets is not installed

--- a/lib/production_toolkit/initializers/lograge.rb
+++ b/lib/production_toolkit/initializers/lograge.rb
@@ -1,6 +1,7 @@
 if defined?(Rails) && Rails.env.production?
   Rails.application.class.configure do
     config.lograge.enabled = true
+    config.lograge.ignore_actions = ['status#index']
 
     # Disable sprockets asset logging
     config.assets.logger = false if config.respond_to?(:assets)

--- a/lib/production_toolkit/rollbar_configurator.rb
+++ b/lib/production_toolkit/rollbar_configurator.rb
@@ -46,7 +46,7 @@ class RollbarConfigurator
       config.environment  = rollbar_config.environment
       config.exception_level_filters.merge!('ActionController::RoutingError' => 'ignore')
       config.scrub_fields |= [:access_token, :client_token, :api_key]
-      config.scrub_headers |= ["X-API-KEY", :access_token]
+      config.scrub_headers |= ["X-API-KEY", :access_token, :client_token, :api_key]
     end
   end
 


### PR DESCRIPTION
WHY

Do not want to log health checks
Pansophy uses api_key in the header
Auth uses client_token in the header